### PR TITLE
fix: correct peerDependencies for bootstrap and popper.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@commitlint/cli": "17.6.1",
         "@commitlint/config-conventional": "17.6.1",
         "autoprefixer": "10.4.14",
+        "bootstrap": "5.2.2",
         "gh-pages": "6.1.1",
         "husky": "8.0.3",
         "nodemon": "2.0.22",
@@ -962,6 +963,7 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "dev": true,
       "peer": true,
       "funding": {
         "type": "opencollective",
@@ -2258,6 +2260,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.2.tgz",
       "integrity": "sha512-dEtzMTV71n6Fhmbg4fYJzQsw1N29hJKO1js5ackCgIpDcGid2ETMGC6zwSYw09v05Y+oRdQ9loC54zB1La3hHQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2268,7 +2271,7 @@
           "url": "https://opencollective.com/bootstrap"
         }
       ],
-      "peer": true,
+      "license": "MIT",
       "peerDependencies": {
         "@popperjs/core": "^2.11.6"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "stylelint-config-standard": "36.0.0"
       },
       "peerDependencies": {
-        "bootstrap": "5.2.2"
+        "bootstrap": "~5.2.0"
       }
     },
     "node_modules/@11ty/dependency-tree": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,7 @@
         "stylelint-config-standard": "36.0.0"
       },
       "peerDependencies": {
-        "bootstrap": "5.2.2",
-        "popper.js": "1.16.1"
+        "bootstrap": "5.2.2"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -10116,18 +10115,6 @@
       "dev": true,
       "dependencies": {
         "semver-compare": "^1.0.0"
-      }
-    },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "watch:sass": "npm run css-compile -- --watch"
   },
   "peerDependencies": {
-    "bootstrap": "5.2.2",
-    "popper.js": "1.16.1"
+    "bootstrap": "5.2.2"
   },
   "devDependencies": {
     "@11ty/eleventy": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@commitlint/cli": "17.6.1",
     "@commitlint/config-conventional": "17.6.1",
     "autoprefixer": "10.4.14",
+    "bootstrap": "5.2.2",
     "gh-pages": "6.1.1",
     "husky": "8.0.3",
     "nodemon": "2.0.22",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "watch:sass": "npm run css-compile -- --watch"
   },
   "peerDependencies": {
-    "bootstrap": "5.2.2"
+    "bootstrap": "~5.2.0"
   },
   "devDependencies": {
     "@11ty/eleventy": "2.0.1",


### PR DESCRIPTION
- Remove `popper.js` peer dependency - it's v1, but bootstrap@5 uses v2, and has [its own peerDependency](https://github.com/twbs/bootstrap/blob/961d5ff9844372a4e294980c667bbe7e0651cdeb/package.json#L104) against it.
- Install `bootstrap@5.2.2` as a `devDependency`
- Relax the `peerDependency` for `bootstrap` to `~5.2.0` it's already used with other 5.2 versions in downstream projects.