### PR TITLE
fix: correct nunjucks templates and generate valid HTML

### DIFF
--- a/docs/example/index.html
+++ b/docs/example/index.html
@@ -209,6 +209,7 @@
 />
             </div>
           </div>
+        </div>
 
         </fieldset>
 

--- a/docs/forms/index.html
+++ b/docs/forms/index.html
@@ -201,6 +201,7 @@
           />
         </div>
       </div>
+    </div>
 
     </fieldset>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -218,7 +218,6 @@ I'm a textarea</textarea
         <span class="visually-hidden">Search</span>
       </button>
     </div>
-  </form>
 
   <div class="mb-3">
     <label class="form-label" for="select-num"
@@ -821,7 +820,7 @@ I'm a textarea</textarea
 <form>
   <div class="form-group">
     <label class="form-label" for="exampleInputEmailAgain"
-      >Email address <span class="field-required">(Required)</label
+      >Email address <span class="field-required">(Required)</span></label
     >
     <input
       type="email"

--- a/docs/otis/module-added/index.html
+++ b/docs/otis/module-added/index.html
@@ -132,6 +132,7 @@
             View archived modules
           </a>
         </li>
+      </ul>
   </div>
 </header>
 
@@ -211,6 +212,7 @@
   </tbody>
 </table>
 </div>
+
 
 
   </main>

--- a/docs/otis/page-layout/index.html
+++ b/docs/otis/page-layout/index.html
@@ -122,6 +122,7 @@
             View archived modules
           </a>
         </li>
+      </ul>
   </div>
 </header>
 
@@ -203,6 +204,7 @@
 </div>
 
   
+
   </main>
 
   <footer class="py-4 mt-5"><hr><small class="d-block mb-0"><a href="https://talis.com/accessibility" rel="noreferrer">Accessibility</a></small><small class="d-block mb-0">Copyright © Talis Education Limited, all rights reserved</small></footer>

--- a/src/docs/_includes/forms-2.njk
+++ b/src/docs/_includes/forms-2.njk
@@ -2,7 +2,7 @@
 <form>
   <div class="form-group">
     <label class="form-label" for="exampleInputEmailAgain"
-      >Email address <span class="field-required">(Required)</label
+      >Email address <span class="field-required">(Required)</span></label
     >
     <input
       type="email"

--- a/src/docs/_includes/forms.njk
+++ b/src/docs/_includes/forms.njk
@@ -32,7 +32,6 @@ I'm a textarea</textarea
         <span class="visually-hidden">Search</span>
       </button>
     </div>
-  </form>
 
   <div class="mb-3">
     <label class="form-label" for="select-num"

--- a/src/docs/example.njk
+++ b/src/docs/example.njk
@@ -111,6 +111,7 @@ title: Register for this imaginary service
 />
             </div>
           </div>
+        </div>
 
         </fieldset>
 

--- a/src/docs/forms.njk
+++ b/src/docs/forms.njk
@@ -98,6 +98,7 @@ title: Forms
           />
         </div>
       </div>
+    </div>
 
     </fieldset>
 

--- a/src/docs/otis/module-added.njk
+++ b/src/docs/otis/module-added.njk
@@ -34,6 +34,7 @@ title: Page Layout Template
             View archived modules
           </a>
         </li>
+      </ul>
   </div>
 </header>
 

--- a/src/docs/otis/page-layout.njk
+++ b/src/docs/otis/page-layout.njk
@@ -24,6 +24,7 @@ title: Page Layout Template
             View archived modules
           </a>
         </li>
+      </ul>
   </div>
 </header>
 


### PR DESCRIPTION
There are a number of invalid HTML Lines in the nunjucks templates. This corrects them and then regenerates the HTML.