### PR TITLE
chore: pin SSH key for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,12 @@ parameters:
     default: v2-dependencies-{{ checksum "package-lock.json" }}
 
 commands:
+  add_deploy_key:
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "SHA256:y6uCZBdmwmyfwepi7fDRF8wN0IVPMKq8MmKYLyFwLuY"
+
   restore_cache_node_modules:
     steps:
       - restore_cache:
@@ -58,6 +64,7 @@ jobs:
   lint_and_test:
     <<: *executor_node
     steps:
+      - add_deploy_key
       - checkout
       - restore_cache_node_modules
       - run:
@@ -83,6 +90,7 @@ jobs:
   publish_release:
     <<: *executor_node
     steps:
+      - add_deploy_key
       - checkout
       - restore_cache_node_modules
       - run:


### PR DESCRIPTION
We use a read/write deploy key from CircleCI, to release changes to GitHub. However, this means we do not have a default read-only deploy key - and _that_ means that each new person who touches the project will generate a new deploy key, breaking the build.

Here, we pin the read/write key, so that we can create a read-only deploy key without breaking the build.