### PR TITLE
fix: allow bootstrap 5.3 as a peer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "stylelint-config-standard": "36.0.1"
       },
       "peerDependencies": {
-        "bootstrap": "~5.2.0"
+        "bootstrap": "^5.2.0"
       }
     },
     "node_modules/@11ty/dependency-tree": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "watch:sass": "npm run css-compile -- --watch"
   },
   "peerDependencies": {
-    "bootstrap": "~5.2.0"
+    "bootstrap": "^5.2.0"
   },
   "devDependencies": {
     "@11ty/eleventy": "3.1.2",


### PR DESCRIPTION
We previously allowed bootstrap versions of `^5.2.0` as a peer; we recently restricted to `~5.2.0`, but it's already used in the wild with 5.3, so relaxing again.