### PR TITLE
chore: use custom.css instead of talis.css

### DIFF
--- a/docs/error/index.html
+++ b/docs/error/index.html
@@ -20,7 +20,7 @@
           media="print"
           onload="this.media='all'" />
 
-    <link rel="stylesheet" href="/bootstrap-theme/assets/css/talis.css" />
+    <link rel="stylesheet" href="/bootstrap-theme/assets/css/custom.css" />
   </head>
   <body class="t-error">
     

--- a/docs/otis/add-module/index.html
+++ b/docs/otis/add-module/index.html
@@ -4,14 +4,14 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
-    <link rel="stylesheet" href="/bootstrap-theme/assets/css/talis.css" />
+    <link rel="stylesheet" href="/bootstrap-theme/assets/css/custom.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap"
       rel="stylesheet"
     />
     <script src="https://kit.fontawesome.com/1f723026cf.js" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>
-    
+
     <title> | Talis</title>
   </head>
   <body>
@@ -34,25 +34,25 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-        
-          
-          
 
-          
+
+
+
+
 
           <li class="nav-item">
             <a class="nav-link "  href="/bootstrap-theme/formsA/">Forms</a>
           </li>
-        
-          
-          
 
-          
+
+
+
+
 
           <li class="nav-item">
             <a class="nav-link "  href="/bootstrap-theme/error/">Error</a>
           </li>
-        
+
         <li class="nav-item">
           <button class="nav-link js-loader-toggle" type="button">
             Toggle loader
@@ -138,7 +138,7 @@
 </nav>
 
   <div class="container">
-      
+
   <main id="content" tabindex="-1">
     <div class="d-flex justify-content-between align-items-center">
   <nav aria-label="breadcrumb">

--- a/docs/otis/edreset-module/index.html
+++ b/docs/otis/edreset-module/index.html
@@ -4,14 +4,14 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
-    <link rel="stylesheet" href="/bootstrap-theme/assets/css/talis.css" />
+    <link rel="stylesheet" href="/bootstrap-theme/assets/css/custom.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap"
       rel="stylesheet"
     />
     <script src="https://kit.fontawesome.com/1f723026cf.js" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>
-    
+
     <title> | Talis</title>
   </head>
   <body>
@@ -34,25 +34,25 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-        
-          
-          
 
-          
+
+
+
+
 
           <li class="nav-item">
             <a class="nav-link "  href="/bootstrap-theme/formsA/">Forms</a>
           </li>
-        
-          
-          
 
-          
+
+
+
+
 
           <li class="nav-item">
             <a class="nav-link "  href="/bootstrap-theme/error/">Error</a>
           </li>
-        
+
         <li class="nav-item">
           <button class="nav-link js-loader-toggle" type="button">
             Toggle loader
@@ -135,7 +135,7 @@
 </nav>
 
   <div class="container">
-      
+
   <main id="content" tabindex="-1">
     <div class="d-flex justify-content-between align-items-center">
   <nav aria-label="breadcrumb">

--- a/docs/otis/reset-module/index.html
+++ b/docs/otis/reset-module/index.html
@@ -4,14 +4,14 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
-    <link rel="stylesheet" href="/bootstrap-theme/assets/css/talis.css" />
+    <link rel="stylesheet" href="/bootstrap-theme/assets/css/custom.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap"
       rel="stylesheet"
     />
     <script src="https://kit.fontawesome.com/1f723026cf.js" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>
-    
+
     <title> | Talis</title>
   </head>
   <body>
@@ -34,25 +34,25 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-        
-          
-          
 
-          
+
+
+
+
 
           <li class="nav-item">
             <a class="nav-link "  href="/bootstrap-theme/formsA/">Forms</a>
           </li>
-        
-          
-          
 
-          
+
+
+
+
 
           <li class="nav-item">
             <a class="nav-link "  href="/bootstrap-theme/error/">Error</a>
           </li>
-        
+
         <li class="nav-item">
           <button class="nav-link js-loader-toggle" type="button">
             Toggle loader
@@ -141,7 +141,7 @@
 </nav>
 
   <div class="container">
-      
+
   <main id="content" tabindex="-1">
     <div class="d-flex justify-content-between align-items-center">
   <nav aria-label="breadcrumb">

--- a/docs/page-layout/index.html
+++ b/docs/page-layout/index.html
@@ -4,14 +4,14 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
-    <link rel="stylesheet" href="/bootstrap-theme/assets/css/talis.css" />
+    <link rel="stylesheet" href="/bootstrap-theme/assets/css/custom.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap"
       rel="stylesheet"
     />
     <script src="https://kit.fontawesome.com/1f723026cf.js" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>
-    
+
     <title>Page Layout Template | Talis</title>
   </head>
   <body>
@@ -34,25 +34,25 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-        
-          
-          
 
-          
+
+
+
+
 
           <li class="nav-item">
             <a class="nav-link "  href="/bootstrap-theme/formsA/">Forms</a>
           </li>
-        
-          
-          
 
-          
+
+
+
+
 
           <li class="nav-item">
             <a class="nav-link "  href="/bootstrap-theme/error/">Error</a>
           </li>
-        
+
         <li class="nav-item">
           <button class="nav-link js-loader-toggle" type="button">
             Toggle loader
@@ -112,9 +112,9 @@
 </nav>
 
   <div class="container">
-      
+
   <main id="content" tabindex="-1">
-    
+
 
 
 <div class="alert alert-success d-flex justify-content-between align-items-center">

--- a/docs/player/annotation/index.html
+++ b/docs/player/annotation/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
-    <link rel="stylesheet" href="/bootstrap-theme/assets/css/talis.css" />
+    <link rel="stylesheet" href="/bootstrap-theme/assets/css/custom.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap"
       rel="stylesheet"

--- a/src/docs/_includes/layouts/error.njk
+++ b/src/docs/_includes/layouts/error.njk
@@ -23,7 +23,7 @@ title: Error Page
           media="print"
           onload="this.media='all'" />
 
-    <link rel="stylesheet" href="{{ '/assets/css/talis.css' | url }}" />
+    <link rel="stylesheet" href="{{ '/assets/css/custom.css' | url }}" />
   </head>
   <body class="t-error">
     {{ content | safe }}

--- a/src/docs/_includes/layouts/player.njk
+++ b/src/docs/_includes/layouts/player.njk
@@ -8,7 +8,7 @@ title: player
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
-    <link rel="stylesheet" href="{{ '/assets/css/talis.css' | url }}" />
+    <link rel="stylesheet" href="{{ '/assets/css/custom.css' | url }}" />
     <link
       href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap"
       rel="stylesheet"


### PR DESCRIPTION
We removed talis.css, but it was still referenced in some of the files. Here we use custom.css in its place.