### PR TITLE
chore: consolidate run scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,9 +75,6 @@ jobs:
           name: "Lint"
           command: npm run lint
       - run:
-          name: "Test"
-          command: npm run test
-      - run:
           name: "Build"
           command: npm run build
       - run:

--- a/README.md
+++ b/README.md
@@ -129,15 +129,13 @@ npm run build
 
 The following npm scripts are available.
 
-| Script        | Description                                                                                              |
-| ------------- | -------------------------------------------------------------------------------------------------------- |
-| `docs`        | Builds the Eleventy-powered documentation site                                                           |
-| `server`      | Starts a local server (<http://localhost:3000>) for development                                          |
-| `watch`       | Automatically recompiles CSS as it watches the `scss` directory for changes                              |
-| `css`         | Runs `css-compile`.                                                                                      |
-| `css-compile` | Compiles source Sass into CSS                                                                            |
-| `lint`        | Runs [Prettier] over sources, and [Stylelint](https://stylelint.io) against source Sass for code quality |
-| `test`        | Runs `css-lint` and `css`, in sequential order                                                           |
+| Script      | Description                                                                                              |
+| ----------- | -------------------------------------------------------------------------------------------------------- |
+| `docs`      | Builds the Eleventy-powered documentation site                                                           |
+| `server`    | Starts a local server (<http://localhost:3000>) for development                                          |
+| `build:css` | Compiles source Sass into CSS                                                                            |
+| `watch`     | Runs `build:css` in watch-mode, recompiling CSS as the `scss` directory changes                          |
+| `lint`      | Runs [Prettier] over sources, and [Stylelint](https://stylelint.io) against source Sass for code quality |
 
 ### Stylelint
 

--- a/package.json
+++ b/package.json
@@ -16,10 +16,8 @@
   "homepage": "https://github.com/techfromsage/bootstrap-theme#readme",
   "scripts": {
     "build": "npm-run-all build:*",
-    "build:css": "npm run css-compile",
+    "build:css": "sass scss/:docs/assets/css/ --style=compressed --load-path=node_modules --source-map",
     "build:eleventy": "eleventy",
-    "css": "npm-run-all css-compile",
-    "css-compile": "sass scss/:docs/assets/css/ --style=compressed --load-path=node_modules --source-map",
     "format": "npm-run-all format:*",
     "format:prettier": "prettier --write .",
     "format:stylelint": "stylelint scss/ --fix",
@@ -31,10 +29,9 @@
     "release": "standard-version",
     "server": "serve docs --listen 3000",
     "start": "npm-run-all --parallel build:css watch:*",
-    "test": "npm-run-all css",
-    "watch": "nodemon -e html,scss -x \"npm run css\"",
+    "watch": "nodemon -e html,scss -x \"npm run build:css\"",
     "watch:eleventy": "eleventy --serve",
-    "watch:sass": "npm run css-compile -- --watch"
+    "watch:sass": "npm run build:css -- --watch"
   },
   "peerDependencies": {
     "bootstrap": "^5.2.0"


### PR DESCRIPTION
Consolidate `npm run` scripts, because we basically had four doing the same thing.

Here, we anoint `build:css` as the only script for SASS compilation. We remove the following which all called one another:
- `css`
- `css-compile`
- `test` (it wasn't actually testing!)