### PR TITLE
chore: remove legacy eleventy redirect

### DIFF
--- a/docs/_eleventy_redirect/index.html
+++ b/docs/_eleventy_redirect/index.html
@@ -1,4 +1,0 @@
-<!doctype html>
-  <meta http-equiv="refresh" content="0; url=/bootstrap-theme/">
-  <title>Browsersync pathPrefix Redirect</title>
-  <a href="/bootstrap-theme/">Go to /bootstrap-theme/</a>


### PR DESCRIPTION
Removes a legacy redirects file doesn't appear to be used.