### PR TITLE
chore: ensure docs and build are aligned

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,9 @@ jobs:
           name: "Lint"
           command: npm run lint
       - run:
+          name: "Remove docs directory - to ensure all files are produced by build"
+          command: rm -rf docs
+      - run:
           name: "Build"
           command: npm run build
       - run:


### PR DESCRIPTION
To ensure that the `docs` directory that _is_ under source control is aligned with the output of the build, remove it before we conduct a porcelain check. Ultimately, we may remove `docs` entirely, but this will stop drift in the interim.