### PR TITLE
fix(PLT-1923): mark access as public

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "url": "git+https://github.com/techfromsage/bootstrap-theme.git"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "private": false,
   "version": "3.1.0",


### PR DESCRIPTION
#### Problem

- https://techfromsage.atlassian.net/browse/PLT-1923
#### Change/Fix

Marks the package as `access=public` in the publish config.

#### Checklist

- [ ] PO review
- [ ] Branch build
- [ ] UX review
- [ ] Accessibility review (See: https://github.com/talis/elevate-app/wiki/Accessibility)
